### PR TITLE
Update 'grab' command

### DIFF
--- a/bin/h
+++ b/bin/h
@@ -44,7 +44,7 @@ actions = {
   # Backups
   backups:   'pg:backups',
   capture:   'pg:backups capture',
-  grab:      'pg:backups url',
+  grab:      'pg:backups public-url',
   # No mapping, but listed for completeness
   ps:        'ps',
   addons:    'addons',


### PR DESCRIPTION
Heroku now uses 'public-url' instead of just 'url'.