### PR TITLE
Fallback to specified env if no mapping is present

### DIFF
--- a/bin/h
+++ b/bin/h
@@ -7,12 +7,12 @@ if File.exists?(path)
 else
   puts '~/.heroku-apps.json must be configured for your environments before '\
        'using `h`'
-  exit(-1)
+  exit(1)
 end
 
 action_key = ARGV.shift
 environment = ARGV.pop
-real_environment = environment ? envs[environment] : nil
+real_environment = environment ? envs[environment] || environment : nil
 action_args = ARGV
 
 actions = {


### PR DESCRIPTION
This allows apps to be specified using their full name in cases where
heroku-apps.json does not contain a mapping.